### PR TITLE
initial argo workflows support

### DIFF
--- a/transpire/helpers/render.py
+++ b/transpire/helpers/render.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Union
 from .postprocessor import postprocess
 import yaml
 

--- a/transpire/resources/ci.py
+++ b/transpire/resources/ci.py
@@ -1,0 +1,309 @@
+from typing import List
+
+# We don't use the argo pyhton library because it doesn't typecheck anyway.
+# The way it checks types is by calling _check_types(), which my IDE doesn't understand
+# and I figure if I'm going to have to google anything anyway I'll just write a plain dict.
+class CIPipeline:
+    def event_source(url: str) -> List[dict]:
+        return [
+            {
+                "apiVersion": "argoproj.io/v1alpha1",
+                "kind": "EventSource",
+                "metadata": {"name": "webhook"},
+                "spec": {
+                    "service": {"ports": [{"port": 12000, "targetPort": 12000}]},
+                    "webhook": {
+                        "github": {
+                            "port": "12000",
+                            "endpoint": "/github",
+                            "method": "POST",
+                        }
+                    },
+                },
+            }
+        ]
+
+    def sensor(name: str, repo: str) -> dict:
+        return {
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "Sensor",
+            "metadata": {"name": name},
+            "spec": {
+                "template": {"serviceAccountName": "operate-workflow-sa"},
+                "dependencies": [
+                    {
+                        "name": "test-dep",
+                        "eventSourceName": "webhook",
+                        "eventName": "example",
+                        "filters": {
+                            "dataLogicalOperator": "and",
+                            "data": [
+                                {
+                                    "path": "repository.full_name",
+                                    "type": "string",
+                                    "value": [repo],
+                                },
+                                {
+                                    "path": "pusher.email",
+                                    "type": "string",
+                                    "comparator": "!=",
+                                    "value": "1-800-NOT-A-REAL-EMAIL@example.com",
+                                }
+                            ],
+                        },
+                    }
+                ],
+                "triggers": [
+                    {
+                        "template": {
+                            "name": "transpire-remote-build",
+                            "k8s": {
+                                "operation": "create",
+                                "source": {
+                                    "resource": {
+                                        "apiVersion": "argoproj.io/v1alpha1",
+                                        "kind": "Workflow",
+                                        "metadata": {
+                                            "generateName": "cluster-workflow-template-hello-world-"
+                                        },
+                                        "spec": {
+                                            "entrypoint": "whalesay-template",
+                                            "arguments": {
+                                                "parameters": [
+                                                    {
+                                                        "name": "message",
+                                                        "value": "hello world",
+                                                    }
+                                                ]
+                                            },
+                                            "workflowTemplateRef": {
+                                                "name": "cluster-workflow-template-whalesay-template",
+                                                "clusterScope": True,
+                                            },
+                                        },
+                                    }
+                                },
+                                "parameters": [
+                                    {
+                                        "src": {
+                                            "dependencyName": "test-dep",
+                                            "dataKey": "body",
+                                        },
+                                        "dest": "spec.arguments.parameters.0.value",
+                                    }
+                                ],
+                            },
+                        }
+                    }
+                ],
+            },
+        }
+
+    def template() -> dict:
+        return {
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "WorkflowTemplate",
+            "metadata": {"name": "transpire-remote-build"},
+            "spec": {
+                "arguments": {
+                    "parameters": [
+                        {
+                            "name": "source-repo",
+                            "value": "https://github.com/ocf/templates",
+                        },
+                        {"name": "source-branch", "value": "main"},
+                        {"name": "path", "value": ""},
+                        {
+                            "name": "cluster-repo",
+                            "value": "https://github.com/ocf/cluster",
+                        },
+                        {"name": "cluster-branch", "value": "main"},
+                    ]
+                },
+                "entrypoint": "main",
+                "volumeClaimTemplates": [
+                    {
+                        "metadata": {"name": "work"},
+                        "spec": {
+                            "accessModes": ["ReadWriteOnce"],
+                            "resources": {"requests": {"storage": "128Mi"}},
+                        },
+                    }
+                ],
+                "volumeClaimGC": {
+                    "strategy": "OnWorkflowCompletion",
+                },
+                "templates": [
+                    {
+                        "name": "main",
+                        "dag": {
+                            "tasks": [
+                                {
+                                    "name": "clone",
+                                    "template": "clone",
+                                    "arguments": {
+                                        "parameters": [
+                                            {
+                                                "name": "repo",
+                                                "value": "{{workflow.parameters.source-repo}}",
+                                            },
+                                            {
+                                                "name": "branch",
+                                                "value": "{{workflow.parameters.source-branch}}",
+                                            },
+                                        ]
+                                    },
+                                },
+                                {
+                                    "name": "objects",
+                                    "template": "objects",
+                                    "arguments": {
+                                        "parameters": [
+                                            {
+                                                "name": "path",
+                                                "value": "{{workflow.parameters.path}}",
+                                            }
+                                        ]
+                                    },
+                                    "depends": "clone",
+                                },
+                                {
+                                    "name": "image",
+                                    "template": "image",
+                                    "arguments": {
+                                        "parameters": [
+                                            {
+                                                "name": "path",
+                                                "value": "{{workflow.parameters.path}}",
+                                            },
+                                        ]
+                                    },
+                                    "depends": "clone",
+                                },
+                                {
+                                    "name": "test",
+                                    "template": "test",
+                                    "arguments": {
+                                        "parameters": [
+                                            {
+                                                "name": "path",
+                                                "value": "{{workflow.parameters.path}}",
+                                            },
+                                        ]
+                                    },
+                                    "depends": "image",
+                                },
+                                {
+                                    "name": "deploy",
+                                    "template": "deploy",
+                                    "arguments": {
+                                        "parameters": [
+                                            {
+                                                "name": "repo",
+                                                "value": "{{workflow.parameters.cluster-repo}}",
+                                            },
+                                            {
+                                                "name": "branch",
+                                                "value": "{{workflow.parameters.cluster-branch}}",
+                                            },
+                                            {
+                                                "name": "path",
+                                                "value": "{{workflow.parameters.path}}",
+                                            },
+                                        ]
+                                    },
+                                    "depends": "test && image && objects",
+                                },
+                            ]
+                        },
+                    },
+                    {
+                        "name": "clone",
+                        "inputs": {
+                            "parameters": [{"name": "repo"}, {"name": "branch"}]
+                        },
+                        "container": {
+                            "volumeMounts": [{"mountPath": "/work", "name": "work"}],
+                            "image": "alpine/git:v2.32.0",
+                            "workingDir": "/work",
+                            "args": [
+                                "clone",
+                                "--depth",
+                                "1",
+                                "--branch",
+                                "{{inputs.parameters.branch}}",
+                                "--single-branch",
+                                "{{inputs.parameters.repo}}",
+                                "source",
+                            ],
+                        },
+                    },
+                    {
+                        "name": "objects",
+                        "inputs": {"parameters": [{"name": "path"}]},
+                        "container": {
+                            "image": "harbor.ocf.berkeley.edu/transpire/runner:latest",
+                            "volumeMounts": [{"mountPath": "/work", "name": "work"}],
+                            "workingDir": "/work/source/{{inputs.parameters.path}}",
+                            "env": [
+                                {"name": "TRANSPIRE_CONTEXT", "value": "ci"},
+                                {
+                                    "name": "TRANSPIRE_OBJECT_OUTPUT",
+                                    "value": "/work/objects",
+                                },
+                            ],
+                            "command": ["transpire"],
+                            "args": ["object", "build"],
+                        },
+                    },
+                    {
+                        "name": "image",
+                        "inputs": {"parameters": [{"name": "path"}]},
+                        "container": {
+                            "image": "harbor.ocf.berkeley.edu/transpire/runner:latest",
+                            "volumeMounts": [{"mountPath": "/work", "name": "work"}],
+                            "workingDir": "/work/source/{{inputs.parameters.path}}",
+                            "env": [
+                                {"name": "TRANSPIRE_CONTEXT", "value": "ci"},
+                            ],
+                            "command": ["transpire"],
+                            "args": ["image", "build", "--push"],
+                        },
+                    },
+                    {
+                        "name": "test",
+                        "inputs": {"parameters": [{"name": "path"}]},
+                        "container": {
+                            "image": "harbor.ocf.berkeley.edu/transpire/runner:latest",
+                            "volumeMounts": [{"mountPath": "/work", "name": "work"}],
+                            "workingDir": "/work/source/{{inputs.parameters.path}}",
+                            "env": [
+                                {"name": "TRANSPIRE_CONTEXT", "value": "ci"},
+                            ],
+                            "command": ["transpire"],
+                            "args": ["image", "test"],
+                        },
+                    },
+                    {
+                        "name": "deploy",
+                        "inputs": {
+                            "parameters": [{"name": "repo"}, {"name": "branch"}]
+                        },
+                        "container": {
+                            "image": "harbor.ocf.berkeley.edu/transpire/runner:latest",
+                            "volumeMounts": [{"mountPath": "/work", "name": "work"}],
+                            "workingDir": "/work",
+                            "env": [
+                                {"name": "TRANSPIRE_CONTEXT", "value": "ci"},
+                                {
+                                    "name": "TRANSPIRE_OBJECT_OUTPUT",
+                                    "value": "/work/objects",
+                                },
+                            ],
+                            "command": ["transpire"],
+                            "args": ["object", "push"],
+                        },
+                    },
+                ],
+            },
+        }

--- a/transpire/resources/ci.py
+++ b/transpire/resources/ci.py
@@ -9,7 +9,7 @@ class CIPipeline:
             {
                 "apiVersion": "argoproj.io/v1alpha1",
                 "kind": "EventSource",
-                "metadata": {"name": "webhook"},
+                "metadata": {"name": "github"},
                 "spec": {
                     "service": {"ports": [{"port": 12000, "targetPort": 12000}]},
                     "webhook": {
@@ -32,9 +32,9 @@ class CIPipeline:
                 "template": {"serviceAccountName": "operate-workflow-sa"},
                 "dependencies": [
                     {
-                        "name": "test-dep",
-                        "eventSourceName": "webhook",
-                        "eventName": "example",
+                        "name": "github",
+                        "eventSourceName": "github",
+                        "eventName": "github",
                         "filters": {
                             "dataLogicalOperator": "and",
                             "data": [
@@ -47,8 +47,8 @@ class CIPipeline:
                                     "path": "pusher.email",
                                     "type": "string",
                                     "comparator": "!=",
-                                    "value": "1-800-NOT-A-REAL-EMAIL@example.com",
-                                }
+                                    "value": "1-800-NOT-A-REAL-EMAIL@woah@example.com",
+                                },
                             ],
                         },
                     }
@@ -64,21 +64,34 @@ class CIPipeline:
                                         "apiVersion": "argoproj.io/v1alpha1",
                                         "kind": "Workflow",
                                         "metadata": {
-                                            "generateName": "cluster-workflow-template-hello-world-"
+                                            "generateName": "transpire-build-"
                                         },
                                         "spec": {
-                                            "entrypoint": "whalesay-template",
+                                            "entrypoint": "main",
                                             "arguments": {
                                                 "parameters": [
                                                     {
-                                                        "name": "message",
-                                                        "value": "hello world",
-                                                    }
+                                                        "name": "source-repo",
+                                                        "value": "https://github.com/ocf/templates",
+                                                    },
+                                                    {
+                                                        "name": "source-branch",
+                                                        "value": "main",
+                                                    },
+                                                    {"name": "path", "value": ""},
+                                                    {
+                                                        "name": "cluster-repo",
+                                                        "value": "https://github.com/ocf/cluster",
+                                                    },
+                                                    {
+                                                        "name": "cluster-branch",
+                                                        "value": "main",
+                                                    },
                                                 ]
                                             },
                                             "workflowTemplateRef": {
-                                                "name": "cluster-workflow-template-whalesay-template",
-                                                "clusterScope": True,
+                                                "name": "transpire-remote-build",
+                                                "clusterScope": False,
                                             },
                                         },
                                     }
@@ -86,11 +99,18 @@ class CIPipeline:
                                 "parameters": [
                                     {
                                         "src": {
-                                            "dependencyName": "test-dep",
-                                            "dataKey": "body",
+                                            "dependencyName": "github",
+                                            "dataKey": "body.clone_url",
                                         },
                                         "dest": "spec.arguments.parameters.0.value",
-                                    }
+                                    },
+                                    {
+                                        "src": {
+                                            "dependencyName": "github",
+                                            "dataKey": "body.after",
+                                        },
+                                        "dest": "spec.arguments.parameters.1.value",
+                                    },
                                 ],
                             },
                         }


### PR DESCRIPTION
How this works:
- The event source listens to events from Github.
- We create a sensor for every project we want to listen to, that starts a new instance of the workflow on push to that repository.
- We run the CI DAG as normal.